### PR TITLE
URL Cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "asciidoctor"

--- a/README.adoc
+++ b/README.adoc
@@ -29,7 +29,7 @@ How can you achieve that? There are number of ways but one of them is just to:
 Easy, isn't it? Unfortunately, it's not that easy and we'll focus on that later on. Right now let's check another
 common deployment process which is the blue green deployment.
 
-Have you ever heard of http://martinfowler.com/bliki/BlueGreenDeployment.html[blue green deployment]? With Cloud Foundry it's
+Have you ever heard of https://martinfowler.com/bliki/BlueGreenDeployment.html[blue green deployment]? With Cloud Foundry it's
  extremely easy to do. Just check out https://spring.io/blog/2014/04/04/project-sagan-zero-downtime-deployments[this article] where
  we describe it in more depth. To quickly recap, doing blue green deployment is as simple as:
 
@@ -48,7 +48,7 @@ you can easily rollback your router to point to a previous environment just by "
 After reading all of the above you could ask yourself a question: _What does zero downtime deployment have to do with Blue green deployment?_
 
 Well, they have quite a lot in common since maintaining two copies of the same environment leads to doubling the effort
-required to support it. That's why some teams, as http://martinfowler.com/bliki/BlueGreenDeployment.html[Martin Fowler states it],
+required to support it. That's why some teams, as https://martinfowler.com/bliki/BlueGreenDeployment.html[Martin Fowler states it],
 tend to perform a variation of that approach:
 
 [quote]
@@ -85,7 +85,7 @@ let's focus on schema versioning first.
 
 ==== Schema versioning
 
-In this article we will use http://flywaydb.org[Flyway] as a schema versioning tool. Naturally we're also writing a Spring Boot application
+In this article we will use https://flywaydb.org[Flyway] as a schema versioning tool. Naturally we're also writing a Spring Boot application
 that has native support for Flyway and will execute the schema migration upon application context setup. When using Flyway
  you can store the migration scripts inside your projects folder (by default under `classpath:db/migration`). Here you can see an example
  of such migration files
@@ -115,7 +115,7 @@ insert into PERSON (first_name, last_name) values ('Dave', 'Syer');
 -----
 
 It's pretty self-explanatory: you can use SQL to define how your database should be changed. For more information about Spring Boot
-and Flyway http://docs.spring.io/spring-boot/docs/1.3.5.RELEASE/reference/html/howto-database-initialization.html#howto-execute-flyway-database-migrations-on-startup[check the Spring Boot Docs].
+and Flyway https://docs.spring.io/spring-boot/docs/1.3.5.RELEASE/reference/html/howto-database-initialization.html#howto-execute-flyway-database-migrations-on-startup[check the Spring Boot Docs].
 
 Using a schema versioning tool with Spring Boot, you receive 2 great benefits.
 
@@ -801,5 +801,5 @@ so that you can review the state of the database (the default jdbc url is
 
 == Additional Reading
 
-- http://databaserefactoring.com[Database Refactoring patterns]
-- http://martinfowler.com/bliki/ContinuousDelivery.html[Continuous Delivery]
+- https://databaserefactoring.com[Database Refactoring patterns]
+- https://martinfowler.com/bliki/ContinuousDelivery.html[Continuous Delivery]

--- a/zero-downtime.adoc
+++ b/zero-downtime.adoc
@@ -29,7 +29,7 @@ How can you achieve that? There are number of ways but one of them is just to:
 Easy, isn't it? Unfortunately, it's not that easy and we'll focus on that later on. Right now let's check another
 common deployment process which is the blue green deployment.
 
-Have you ever heard of http://martinfowler.com/bliki/BlueGreenDeployment.html[blue green deployment]? With Cloud Foundry it's
+Have you ever heard of https://martinfowler.com/bliki/BlueGreenDeployment.html[blue green deployment]? With Cloud Foundry it's
  extremely easy to do. Just check out https://spring.io/blog/2014/04/04/project-sagan-zero-downtime-deployments[this article] where
  we describe it in more depth. To quickly recap, doing blue green deployment is as simple as:
 
@@ -48,7 +48,7 @@ you can easily rollback your router to point to a previous environment just by "
 After reading all of the above you could ask yourself a question: _What does zero downtime deployment have to do with Blue green deployment?_
 
 Well, they have quite a lot in common since maintaining two copies of the same environment leads to doubling the effort
-required to support it. That's why some teams, as http://martinfowler.com/bliki/BlueGreenDeployment.html[Martin Fowler states it],
+required to support it. That's why some teams, as https://martinfowler.com/bliki/BlueGreenDeployment.html[Martin Fowler states it],
 tend to perform a variation of that approach:
 
 [quote]
@@ -85,7 +85,7 @@ let's focus on schema versioning first.
 
 ==== Schema versioning
 
-In this article we will use http://flywaydb.org[Flyway] as a schema versioning tool. Naturally we're also writing a Spring Boot application
+In this article we will use https://flywaydb.org[Flyway] as a schema versioning tool. Naturally we're also writing a Spring Boot application
 that has native support for Flyway and will execute the schema migration upon application context setup. When using Flyway
  you can store the migration scripts inside your projects folder (by default under `classpath:db/migration`). Here you can see an example
  of such migration files
@@ -109,7 +109,7 @@ include::boot-flyway-v4/src/main/resources/db/migration/V1__init.sql[]
 -----
 
 It's pretty self-explanatory: you can use SQL to define how your database should be changed. For more information about Spring Boot
-and Flyway http://docs.spring.io/spring-boot/docs/1.3.5.RELEASE/reference/html/howto-database-initialization.html#howto-execute-flyway-database-migrations-on-startup[check the Spring Boot Docs].
+and Flyway https://docs.spring.io/spring-boot/docs/1.3.5.RELEASE/reference/html/howto-database-initialization.html#howto-execute-flyway-database-migrations-on-startup[check the Spring Boot Docs].
 
 Using a schema versioning tool with Spring Boot, you receive 2 great benefits.
 
@@ -234,5 +234,5 @@ so that you can review the state of the database (the default jdbc url is
 
 == Additional Reading
 
-- http://databaserefactoring.com[Database Refactoring patterns]
-- http://martinfowler.com/bliki/ContinuousDelivery.html[Continuous Delivery]
+- https://databaserefactoring.com[Database Refactoring patterns]
+- https://martinfowler.com/bliki/ContinuousDelivery.html[Continuous Delivery]


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://databaserefactoring.com with 2 occurrences migrated to:  
  https://databaserefactoring.com ([https](https://databaserefactoring.com) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/1.3.5.RELEASE/reference/html/howto-database-initialization.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/1.3.5.RELEASE/reference/html/howto-database-initialization.html ([https](https://docs.spring.io/spring-boot/docs/1.3.5.RELEASE/reference/html/howto-database-initialization.html) result 200).
* [ ] http://flywaydb.org with 2 occurrences migrated to:  
  https://flywaydb.org ([https](https://flywaydb.org) result 200).
* [ ] http://martinfowler.com/bliki/BlueGreenDeployment.html with 4 occurrences migrated to:  
  https://martinfowler.com/bliki/BlueGreenDeployment.html ([https](https://martinfowler.com/bliki/BlueGreenDeployment.html) result 200).
* [ ] http://martinfowler.com/bliki/ContinuousDelivery.html with 2 occurrences migrated to:  
  https://martinfowler.com/bliki/ContinuousDelivery.html ([https](https://martinfowler.com/bliki/ContinuousDelivery.html) result 200).
* [ ] http://rubygems.org with 1 occurrences migrated to:  
  https://rubygems.org ([https](https://rubygems.org) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/flyway with 2 occurrences
* http://localhost:8080/h2-console with 2 occurrences